### PR TITLE
chore: bump ibis lower bound

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -24,12 +24,11 @@ requirements:
     - python >=3.9
     - poetry-core
   run:
-    - ibis-framework-core >=4
+    - ibis-framework-core >=9
     - packaging >=21.3
     - python >=3.9
     - python-substrait >=0.2.1
     - pyyaml >=5
-    - sqlalchemy >=1.4
     - toolz >=0.11
 
 test:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

ibis-substrait >=4 only supports ibis>=9, updating the recipe to reflect that.